### PR TITLE
Hadoop shim: allow to set effective user, group, and group membership…

### DIFF
--- a/src/java/hadoop-qfs-2/src/main/java/com/quantcast/qfs/hadoop/Qfs.java
+++ b/src/java/hadoop-qfs-2/src/main/java/com/quantcast/qfs/hadoop/Qfs.java
@@ -76,11 +76,12 @@ public class Qfs extends AbstractFileSystem {
       this.qfsImpl = new QFSImpl(
         conf.get("fs.qfs.metaServerHost", ""),
         conf.getInt("fs.qfs.metaServerPort", -1),
-        getStatistics()
+        getStatistics(),
+        conf
       );
     } else {
       this.qfsImpl = new QFSImpl(
-        uri.getHost(), uri.getPort(), getStatistics());
+        uri.getHost(), uri.getPort(), getStatistics(), conf);
     }
     this.qfs = new QuantcastFileSystem2(this.qfsImpl, uri);
   }

--- a/src/java/hadoop-qfs/src/main/java/com/quantcast/qfs/hadoop/QuantcastFileSystem.java
+++ b/src/java/hadoop-qfs/src/main/java/com/quantcast/qfs/hadoop/QuantcastFileSystem.java
@@ -71,9 +71,10 @@ public class QuantcastFileSystem extends FileSystem {
         if (uri.getHost() == null) {
           qfsImpl = createIFSImpl(conf.get("fs.qfs.metaServerHost", ""),
                                 conf.getInt("fs.qfs.metaServerPort", -1),
-                                statistics);
+                                statistics, conf);
         } else {
-          qfsImpl = createIFSImpl(uri.getHost(), uri.getPort(), statistics);
+          qfsImpl = createIFSImpl(uri.getHost(), uri.getPort(),
+                                statistics, conf);
         }
       }
 
@@ -90,8 +91,9 @@ public class QuantcastFileSystem extends FileSystem {
   }
 
   protected IFSImpl createIFSImpl(String metaServerHost, int metaServerPort,
-                               FileSystem.Statistics stats) throws IOException {
-    return new QFSImpl(metaServerHost, metaServerPort, stats);
+                               FileSystem.Statistics stats,
+                               Configuration conf) throws IOException {
+    return new QFSImpl(metaServerHost, metaServerPort, stats, conf);
   }
 
   public Path getWorkingDirectory() {


### PR DESCRIPTION
… with fs.qfs.euser, qfs.qfs.egroup, and fs.qfs.egroups configuration properties. Testing: ~/git/qfs/src/test-scripts/qfshadoop.sh fs -Dfs.qfs.euser=0 -Dfs.qfs.egroup=0 -touchz mytestfile ; ~/git/qfs/src/test-scripts/qfshadoop.sh fs -Dfs.qfs.euser=0 -Dfs.qfs.egroup=0 -ls mytestfile